### PR TITLE
Fixed handling of arguments --recursive

### DIFF
--- a/lib/gulp-galen.js
+++ b/lib/gulp-galen.js
@@ -63,7 +63,12 @@ var GulpEventStream = function (mode, specialOptionKeys) {
       var args = [mode, file.path];
       Object.keys(opt).forEach(function (key) {
         if (opt[key]) {
-          args.push("--" + key + "=" + replacePlaceholders(opt[key], fileInfo));
+          if (typeof opt[key] === "boolean") {
+            // "galen test --recursive" support
+            args.push("--" + key);
+          } else {
+            args.push("--" + key + "=" + replacePlaceholders(opt[key], fileInfo));
+          }
         }
       });
       Object.keys(properties).forEach(function (key) {


### PR DESCRIPTION
When using the `recursive` was incorrect conversion into arguments galen:

```
galen --recursive=true
```

This fix makes the correct conversion:

```
galen --recursive
```
