### PR TITLE
Use nested errors when rethrowing errors to avoid losing information

### DIFF
--- a/lib/gulp-galen.js
+++ b/lib/gulp-galen.js
@@ -1,6 +1,7 @@
 /* globals process */
 
 var spawn = require("child_process").spawn,
+  VError = require('verror'),
   path = require("path"),
   through = require('through'),
   which = require('which');
@@ -39,7 +40,7 @@ var GulpEventStream = function (mode, specialOptionKeys) {
     } catch (e) {
       // this error is thrown by which.sync which is the last fallback option
       
-      throw new Error('Could not find galen executable ' +
+      throw new VError(e, 'Could not find galen executable ' +
         'in project’s local `node_modules/.bin` folders ' +
         'or in global $PATH (' + (process.env.Path || process.env.PATH) + '). ' +
         'You can install it locally or globally by running `npm install [--save-dev|--global] galenframework`. ' +
@@ -101,7 +102,7 @@ var GulpEventStream = function (mode, specialOptionKeys) {
           stream.emit('error', new Error("Test '" + file.path + "' failed!"));
         }
       }).on("error", function (err) {
-        stream.emit('error', new Error("Could not start galen. Galen ('" + galenPath + "') not found?"));
+        stream.emit('error', new VError(err, "Could not start galen. Galen ('" + galenPath + "') not found?"));
       });
     });
   };

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "homepage": "https://github.com/Galeria-Kaufhof/gulp-galen",
   "dependencies": {
     "through": "^2.3.8",
+    "verror": "^1.6.1",
     "which": "^1.2.4"
   },
   "devDependencies": {


### PR DESCRIPTION
If you catch a thrown error and create a new one, all the valuable info of the original exception is lost. Luckily there’s a proper way to handle that, as recommended by Joyent, the actual company which developed Node.js
